### PR TITLE
Increase SD_CARD_SIZE to 1300

### DIFF
--- a/builder/rpi/build.sh
+++ b/builder/rpi/build.sh
@@ -9,7 +9,7 @@ fi
 ### setting up some important variables to control the build process
 BUILD_RESULT_PATH="/workspace"
 IMAGE_PATH="rpi-raw.img"
-SD_CARD_SIZE=1200
+SD_CARD_SIZE=1300
 BOOT_PARTITION_SIZE=64
 
 # create empty BOOT/ROOTFS image file


### PR DESCRIPTION
While adding docker-machine 0.7.0 to image-builder-rpi we seem to exceed the root filesystem size. So increase it.

connects to hypriot/image-builder-rpi#91
