### PR TITLE
Incorporated build logic inside image. Differentiated directory paths  of build scripts and output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 RUN gem update --system && \
     gem install --no-document serverspec
+
+COPY builder /builder/

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ build:
 	docker build -t image-builder-raw .
 
 rpi-raw-image: build
-	docker run --rm --privileged -v $(shell pwd):/workspace image-builder-raw /workspace/builder/rpi/build.sh
+	docker run --rm --privileged -v $(shell pwd):/workspace image-builder-raw /builder/rpi/build.sh
 
 odroid-raw-image: build
-	docker run --rm --privileged -v $(shell pwd):/workspace image-builder-raw /workspace/builder/odroid/build.sh
+	docker run --rm --privileged -v $(shell pwd):/workspace image-builder-raw /builder/odroid/build.sh
 
 shell: build
 	docker run --rm -ti --privileged -v $(shell pwd):/workspace image-builder-raw bash

--- a/builder/odroid/build.sh
+++ b/builder/odroid/build.sh
@@ -66,4 +66,4 @@ cd ${BUILD_RESULT_PATH} && sha256sum "${IMAGE_PATH}.zip" > "${IMAGE_PATH}.zip.sh
 
 fdisk -l /odroid-raw.img
 # test raw image that we have built
-rspec --format documentation --color ${BUILD_RESULT_PATH}/builder/odroid/test
+rspec --format documentation --color /builder/odroid/test

--- a/builder/rpi/build.sh
+++ b/builder/rpi/build.sh
@@ -66,4 +66,4 @@ cd ${BUILD_RESULT_PATH} && sha256sum "${IMAGE_PATH}.zip" > "${IMAGE_PATH}.zip.sh
 
 fdisk -l /rpi-raw.img
 # test raw image that we have built
-rspec --format documentation --color ${BUILD_RESULT_PATH}/builder/rpi/test
+rspec --format documentation --color /builder/rpi/test


### PR DESCRIPTION
Changed the logic so that:
- Build logic is baked into the image and doesn't have to be mapped via a volume
- Directory structure of output and build scripts are completely separate. This allows you to map a volume strictly for output without any pollution from the build scripts themselves.