### PR TITLE
jessie to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     dosfstools \


### PR DESCRIPTION
with jessie:
ERROR:  Error installing serverspec:
	The last version of net-ssh (>= 2.7) to support your Ruby & RubyGems was 4.2.0. Try installing it with `gem install net-ssh -v 4.2.0` and then running the current command again
	net-ssh requires Ruby version >= 2.2.6. The current ruby version is 2.1.0.

Build working with stretch :)