### PR TITLE
Increase SD card size to 1300

### DIFF
--- a/builder/rpi/build.sh
+++ b/builder/rpi/build.sh
@@ -9,7 +9,7 @@ fi
 ### setting up some important variables to control the build process
 BUILD_RESULT_PATH="/workspace"
 IMAGE_PATH="rpi-raw.img"
-SD_CARD_SIZE=1200
+SD_CARD_SIZE=1300
 BOOT_PARTITION_SIZE=64
 
 # create empty BOOT/ROOTFS image file


### PR DESCRIPTION
Strange problem with HypriotOS 1.11.2, after resizing cloud-init still shows errors while booting no space left on device.
Try to increase sd card size.