### PR TITLE
Add boot flag for efi boot

### DIFF
--- a/builder/rpi/build.sh
+++ b/builder/rpi/build.sh
@@ -33,7 +33,7 @@ echo "Image ${IMAGE_PATH} created and mounted as ${DEVICE}."
 sfdisk --force "${DEVICE}" <<PARTITION
 unit: sectors
 
-/dev/loop0p1 : start= ${BOOTFS_START}, size= ${BOOTFS_SIZE}, Id= c
+/dev/loop0p1 : start= ${BOOTFS_START}, size= ${BOOTFS_SIZE}, Id= c, bootable
 /dev/loop0p2 : start= ${ROOTFS_START}, size= ${ROOTFS_SIZE}, Id=83
 /dev/loop0p3 : start= 0, size= 0, Id= 0
 /dev/loop0p4 : start= 0, size= 0, Id= 0

--- a/builder/rpi/test/image_spec.rb
+++ b/builder/rpi/test/image_spec.rb
@@ -18,7 +18,7 @@ describe "Raw Image" do
     end
 
     it "has a boot-partition with a sda1 W95 FAT32 filesystem" do
-      expect(stdout).to contain('^.*\.img1 .*W95 FAT32 \(LBA\)$')
+      expect(stdout).to contain('^.*\.img1 \* .*W95 FAT32 \(LBA\)$')
     end
 
     it "has a root-partition with a sda2 Linux filesystem" do
@@ -26,7 +26,7 @@ describe "Raw Image" do
     end
 
     it "partition sda1 starts at sector 2048" do
-      expect(stdout).to contain('^.*\.img1\ *2048 .*$')
+      expect(stdout).to contain('^.*\.img1\ \* *2048 .*$')
     end
 
     it "partition sda1 has a size of 64M" do


### PR DESCRIPTION
To boot an operating system via UEFI (i.e. https://github.com/pbatard/RPi3 ) it is necessary to enable the boot flag on the boot partition.

Since the boot flag is represented as an "*" in the output of fdisk the unit test also needs some adjustment.